### PR TITLE
READMEにおけるデータベース設計の記載追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,54 @@ Things you may want to cover:
 
 * Database creation
 
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :users, through: groups_users
+
+
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false|
+|password|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :groups, through: groups_users
+
+
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text||
+|image|string||
+|group_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
 * Database initialization
 
 * How to run the test suite


### PR DESCRIPTION
## What
ChatSpaceの仕様に基づき、必要なテーブルおよびそれぞれの関係性を
READMEに記載追加。追加したテーブルは下記の通り。
・groupsテーブル
・usersテーブル
・groups_usersテーブル（中間テーブル）
・messagesテーブル

## Why
ChatSpaceの設計において必要なデータとその関係性を明確にしておくことで、
その後のレイアウトやアクションの作成がスムーズに行えるため初めに実施する。
